### PR TITLE
Tag instances

### DIFF
--- a/bootstrap-linux-example/bootstrap.ps1
+++ b/bootstrap-linux-example/bootstrap.ps1
@@ -26,4 +26,5 @@ knife ec2 server create `
   --user-data ./user-data `
   --associate-public-ip `
   --run-list "[[RECIPE]]" `
-  --environment $environment
+  --environment $environment `
+  --tags "created-by=test-kitchen,demo-type=bjc-campfire"

--- a/bootstrap-windows-example/bootstrap.ps1
+++ b/bootstrap-windows-example/bootstrap.ps1
@@ -29,4 +29,7 @@ knife ec2 server create `
   --winrm-password "$password" `
   --associate-public-ip `
   --run-list "[[RECIPE]]" `
-  --environment $environment
+  --environment $environment `
+  --tags "created-by=test-kitchen,demo-type=bjc-campfire"
+
+

--- a/wannacry/bootstrap.ps1
+++ b/wannacry/bootstrap.ps1
@@ -28,4 +28,5 @@ knife ec2 server create `
   --winrm-password "$password" `
   --associate-public-ip `
   --run-list "role[teardrop]" `
-  --environment "$environment"
+  --environment "$environment" `
+  --tags "created-by=test-kitchen,demo-type=bjc-campfire"


### PR DESCRIPTION
Abuse the `created-by=test-kitchen` tag so they get caught by the reaper.  